### PR TITLE
vote.jsから関数を移植

### DIFF
--- a/public/scripts/pin-map.js
+++ b/public/scripts/pin-map.js
@@ -80,6 +80,16 @@ async function loadBoardPins(pins, layer, status=null) {
   });
 }
 
+function onLocationFound(e) {
+  const radius = e.accuracy / 2;
+
+  const locationMarker = L.marker(e.latlng).addTo(map)
+    .bindPopup("現在地").openPopup();
+  const locationCircle = L.circle(e.latlng, radius).addTo(map);
+
+  map.setView(e.latlng, 14);
+}
+
 function onLocationError(e) {
   // alert(e.message);
   const mapConfig = {


### PR DESCRIPTION
# 変更の概要
- map.js内に function onLocationFound() が未定義のため、mapページが動かない。

```
Uncaught ReferenceError: onLocationFound is not defined
    at pin-map.js:165:25
```

- 上記エラーを解消するため、vote.js内の同名のfunctionをmap.jsに移植します。

